### PR TITLE
LÖVR support

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -11,7 +11,7 @@ local iqm = {
 
 local love = love or lovr
 love.filesystem.getInfo = love.filesystem.getInfo or lovr.filesystem.isFile
-love.filesystem.newFileData = love.filesystem.newFileData or lovr.data.newBlob
+love.data.newByteData = love.data.newByteData or lovr.data.newBlob
 
 iqm.lookup = {}
 
@@ -181,8 +181,8 @@ function iqm.load(file, save_data, preserve_cw)
 		type = ct
 	end
 
-	local filedata = love.filesystem.newFileData(string.rep("\0", header.num_vertexes * ffi.sizeof(type)), "dummy")
-	local vertices = ffi.cast("struct " .. title .. "*", filedata:getPointer())
+	local blob = love.data.newByteData(header.num_vertexes * ffi.sizeof(type))
+	local vertices = ffi.cast("struct " .. title .. "*", blob:getPointer())
 
 	-- TODO: Compute XY + spherical radiuses
 	local computed_bbox = { min = {}, max = {} }
@@ -256,7 +256,7 @@ function iqm.load(file, save_data, preserve_cw)
 		layout[i] = { va.love_type, va.format, va.size }
 	end
 
-	local m = love.graphics.newMesh(layout, filedata, "triangles")
+	local m = love.graphics.newMesh(layout, blob, "triangles")
 	m:setVertexMap(indices)
 
 	-- Decode mesh/material names.

--- a/init.lua
+++ b/init.lua
@@ -1,4 +1,4 @@
-local base = (...):gsub('%.init$', '') .. "."
+local base = (...):gsub('%.?init$', '') .. "."
 local c    = require(base .. "iqm-ffi")
 local ffi  = require "ffi"
 

--- a/init.lua
+++ b/init.lua
@@ -9,6 +9,10 @@ local iqm = {
 	_DESCRIPTION = "Load an IQM 3D model into LÖVE.",
 }
 
+local love = love or lovr
+love.filesystem.getInfo = love.filesystem.getInfo or lovr.filesystem.isFile
+love.filesystem.newFileData = love.filesystem.newFileData or lovr.data.newBlob
+
 iqm.lookup = {}
 
 local function check_magic(magic)
@@ -118,20 +122,20 @@ function iqm.load(file, save_data, preserve_cw)
 	local function translate_format(type)
 		local types = {
 			[c.IQM_FLOAT] = "float",
-			[c.IQM_UBYTE] = "byte",
+			[c.IQM_UBYTE] = lovr and "ubyte" or "byte",
 		}
 		return types[type] or false
 	end
 
 	local function translate_love(type)
 		local types = {
-			position = "VertexPosition",
-			texcoord = "VertexTexCoord",
-			normal   = "VertexNormal",
-			tangent  = "VertexTangent",
-			bone     = "VertexBone",
-			weight   = "VertexWeight",
-			color    = "VertexColor",
+			position = lovr and "lovrPosition" or "VertexPosition",
+			texcoord = lovr and "lovrTexCoord" or "VertexTexCoord",
+			normal   = lovr and "lovrNormal" or "VertexNormal",
+			tangent  = lovr and "lovrTangent" or "VertexTangent",
+			bone     = lovr and "lovrBones" or "VertexBone",
+			weight   = lovr and "lovrBoneWeights" or "VertexWeight",
+			color    = lovr and "lovrVertexColor" or "VertexColor",
 		}
 		return assert(types[type])
 	end

--- a/iqm-ffi.lua
+++ b/iqm-ffi.lua
@@ -11,7 +11,7 @@ ffi.cdef([[
 
 typedef uint32_t uint;
 typedef uint8_t uchar;
-typedef uint8_t byte; // simplifies translation for LOVE.
+typedef uint8_t byte, ubyte; // simplifies translation for LOVE, LOVR.
 
 struct iqmheader
 {


### PR DESCRIPTION
Changes:

- The `.` in `.init` is now optional so the library can be required from a sibling script.
- Use lovr attribute names/types when running in lovr.
- Use a ByteData/Blob and avoid allocating a large empty string.

Need to test this in LÖVE!